### PR TITLE
Enhance blockchain UI

### DIFF
--- a/templates/add_transaction.html
+++ b/templates/add_transaction.html
@@ -22,3 +22,21 @@
   <button type="submit" class="btn btn-primary">Ajouter la transaction</button>
 </form>
 {% endblock %}
+
+{% block scripts %}
+<script>
+  document.querySelector('form').addEventListener('submit', function(e) {
+    const sender = document.getElementById('sender');
+    const recipient = document.getElementById('recipient');
+    const amount = document.getElementById('amount');
+    let valid = true;
+    if (!sender.value.trim()) { sender.classList.add('is-invalid'); valid = false; }
+    if (!recipient.value.trim()) { recipient.classList.add('is-invalid'); valid = false; }
+    const value = parseFloat(amount.value);
+    if (isNaN(value) || value <= 0) { amount.classList.add('is-invalid'); valid = false; }
+    if (!valid) {
+      e.preventDefault();
+    }
+  });
+</script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,14 +4,19 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Blockchain simplifiée</title>
-    <!-- Thème Bootswatch foncé pour un rendu adapté à l'univers blockchain -->
+    <!-- Thème Bootswatch dynamique -->
     <link
+      id="theme-link"
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/cyborg/bootstrap.min.css"
       integrity="sha384-5z6b6vWn64DuHV/qIir+OiyvnN6w4lItEXoyfJqXK0mwgRwlOx2Q/UXxV2LNlFdi"
       crossorigin="anonymous"
     />
     <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/datatables.net-dt@1.13.6/css/jquery.dataTables.min.css"
+    />
   </head>
   <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
@@ -46,6 +51,7 @@
               <a class="nav-link" href="{{ url_for('validate_chain') }}">Valider</a>
             </li>
           </ul>
+          <button id="themeToggle" class="btn btn-secondary ms-auto" type="button">Mode clair</button>
         </div>
       </div>
     </nav>
@@ -66,10 +72,35 @@
       {% endwith %}
       {% block content %}{% endblock %}
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/datatables.net@1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.3.0/dist/chart.umd.min.js"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-ENjdO4Dr2bkBIFxQpeoY9q6bKQTW65XCn5HOvToctwOU8nKg4J8BN6V1k5nwQKp1"
       crossorigin="anonymous"
     ></script>
+    <script>
+      function setTheme(theme) {
+        const link = document.getElementById('theme-link');
+        const btn = document.getElementById('themeToggle');
+        if (theme === 'light') {
+          link.href = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css';
+          btn.textContent = 'Mode sombre';
+        } else {
+          link.href = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/cyborg/bootstrap.min.css';
+          btn.textContent = 'Mode clair';
+        }
+        localStorage.setItem('theme', theme);
+      }
+
+      document.getElementById('themeToggle').addEventListener('click', () => {
+        const current = localStorage.getItem('theme') || 'dark';
+        setTheme(current === 'dark' ? 'light' : 'dark');
+      });
+
+      setTheme(localStorage.getItem('theme') || 'dark');
+    </script>
+    {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/templates/chain.html
+++ b/templates/chain.html
@@ -3,6 +3,28 @@
 {% block content %}
 <h2 class="mb-4">Blockchain complète</h2>
 <p>La chaîne contient {{ chain|length }} bloc{{ 's' if chain|length > 1 else '' }}.</p>
+
+<table id="blocksTable" class="table table-striped table-dark mb-4">
+  <thead>
+    <tr>
+      <th>Index</th>
+      <th>Date</th>
+      <th>Tx</th>
+      <th>Total</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in table_data %}
+    <tr>
+      <td>{{ row.index }}</td>
+      <td>{{ row.timestamp }}</td>
+      <td>{{ row.tx_count }}</td>
+      <td>{{ '%.2f'|format(row.total) }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
 <div class="accordion accordion-flush" id="chainAccordion">
   {% for block in chain %}
   <div class="accordion-item">
@@ -37,4 +59,12 @@
   </div>
   {% endfor %}
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  $(document).ready(function () {
+    $('#blocksTable').DataTable();
+  });
+</script>
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,8 +12,31 @@
           Utilisez la navigation pour consulter la chaîne, ajouter des transactions,
           miner un bloc ou valider l’intégrité de la chaîne.
         </p>
+        <canvas id="txChart" height="200"></canvas>
       </div>
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  const ctx = document.getElementById('txChart');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: {{ labels | tojson }},
+      datasets: [{
+        label: 'Transactions par bloc',
+        data: {{ tx_counts | tojson }},
+        backgroundColor: '#0d6efd'
+      }]
+    },
+    options: {
+      scales: {
+        y: { beginAtZero: true }
+      }
+    }
+  });
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add dynamic theme toggle and include JS libraries
- display blocks summary in sortable table
- plot transaction counts on index page
- validate transaction form in browser
- compute table data server side

## Testing
- `python -m unittest -v tests/test_blockchain.py`

------
https://chatgpt.com/codex/tasks/task_e_6888cc1ebcc4832e89f72a44d3e1a560