### PR TITLE
Improve UI, theme handling and mining hints

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,9 +1,9 @@
-body {
+body.dark {
   background: linear-gradient(135deg, #101020, #1c1c2d);
   color: #f8f9fa;
 }
 
-.card {
+body.dark .card {
   background-color: #212130;
   border-color: #2c2c3c;
 }
@@ -15,4 +15,22 @@ body {
 .navbar-brand {
   font-weight: bold;
   letter-spacing: 1px;
+}
+
+.blockchain-diagram {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.blockchain-diagram .block {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--bs-secondary);
+  border-radius: 0.25rem;
+}
+
+.blockchain-diagram .arrow {
+  font-size: 1.25rem;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -84,12 +84,15 @@
       function setTheme(theme) {
         const link = document.getElementById('theme-link');
         const btn = document.getElementById('themeToggle');
+        const body = document.body;
         if (theme === 'light') {
           link.href = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/flatly/bootstrap.min.css';
           btn.textContent = 'Mode sombre';
+          body.classList.remove('dark');
         } else {
           link.href = 'https://cdn.jsdelivr.net/npm/bootswatch@5.3.0/dist/cyborg/bootstrap.min.css';
           btn.textContent = 'Mode clair';
+          body.classList.add('dark');
         }
         localStorage.setItem('theme', theme);
       }

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,34 +9,22 @@
         <p class="card-text">Nombre de blocs : <strong>{{ chain_length }}</strong></p>
         <p class="card-text">Difficulté actuelle : <strong>{{ difficulty }}</strong></p>
         <p class="card-text">
-          Utilisez la navigation pour consulter la chaîne, ajouter des transactions,
-          miner un bloc ou valider l’intégrité de la chaîne.
+          Utilisez la navigation pour consulter la chaîne, ajouter des transactions
+          puis miner un bloc.
         </p>
-        <canvas id="txChart" height="200"></canvas>
+        <div class="blockchain-diagram my-4">
+          <div class="block">Bloc&nbsp;0</div>
+          <div class="arrow">&rarr;</div>
+          <div class="block">Bloc&nbsp;1</div>
+          <div class="arrow">&rarr;</div>
+          <div class="block">Bloc&nbsp;2</div>
+        </div>
+        <p class="card-text">
+          Pour valider ces transactions, cliquez sur <em>Miner un bloc</em> une fois
+          des transactions ajoutées.
+        </p>
       </div>
     </div>
   </div>
 </div>
-{% endblock %}
-
-{% block scripts %}
-<script>
-  const ctx = document.getElementById('txChart');
-  new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: {{ labels | tojson }},
-      datasets: [{
-        label: 'Transactions par bloc',
-        data: {{ tx_counts | tojson }},
-        backgroundColor: '#0d6efd'
-      }]
-    },
-    options: {
-      scales: {
-        y: { beginAtZero: true }
-      }
-    }
-  });
-</script>
 {% endblock %}

--- a/templates/pending.html
+++ b/templates/pending.html
@@ -3,6 +3,7 @@
 {% block content %}
 <h2 class="mb-4">Transactions en attente</h2>
 {% if pending %}
+<p class="text-muted">Cliquez sur <strong>Miner un bloc</strong> pour valider ces transactions.</p>
 <ul class="list-group">
   {% for tx in pending %}
   <li class="list-group-item mb-2">


### PR DESCRIPTION
## Summary
- simplify theme handling to properly support dark mode
- add simple blockchain diagram on the home page
- provide mining instructions on home and pending pages
- tweak custom styles for dark/light modes

## Testing
- `python -m unittest -v tests/test_blockchain.py`

------
https://chatgpt.com/codex/tasks/task_e_6888d130788c832e82064b418b32f482